### PR TITLE
Fix provider in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, add the plugin to your [CLDR backend](https://hexdocs.pm/ex_cldr/readme.ht
 defmodule MyApp.Cldr do
   use Cldr,
     providers: [
-      Cldr.TimeZoneNames,
+      Cldr.TimeZoneName,
       # ...
     ],
     # ...


### PR DESCRIPTION
The provider name is listed in the Readme as Cldr.TimeZoneNames, where it should read Cldr.TimeZoneName (singular).
Got a Cldr backend not found and eventually found the error was in the provider. :)

BTW, thanks for the package. 👍 